### PR TITLE
Allow for multiple classNames as an option

### DIFF
--- a/cypress/integration/notyf_spec.js
+++ b/cypress/integration/notyf_spec.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 
 context('Notyf', () => {
-  
+
   function init(config) {
     if (config) {
       typeCode(config);
@@ -23,12 +23,12 @@ context('Notyf', () => {
     it('should render the main container', () => {
       cy.get('.notyf');
     });
-    
+
     it('should render a success notification', () => {
       cy.get('#success-btn').click();
       cy.get('.notyf__toast').should('have.class', 'notyf__toast--success');
     });
-  
+
     it('should render an error notification', () => {
       cy.get('#error-btn').click();
       cy.get('.notyf__toast').should('have.class', 'notyf__toast--error');
@@ -200,6 +200,14 @@ context('Notyf', () => {
 
     it('should render with custom class name', () => {
       const className = 'foo-bar-class';
+      const config = { className };
+      typeCode(config);
+      cy.get('#success-btn').click();
+      cy.get('.notyf__toast').should('have.class', className);
+    });
+
+    it('should render with multiple custom class names', () => {
+      const className = 'foo-bar-class another-class';
       const config = { className };
       typeCode(config);
       cy.get('#success-btn').click();

--- a/src/notyf.view.ts
+++ b/src/notyf.view.ts
@@ -61,7 +61,7 @@ export class NotyfView {
     const card = this._buildNotificationCard(notification);
     const className = notification.options.className;
     if (className) {
-      card.classList.add(className);
+      card.classList.add(...className.split(' '));
     }
     this.container.appendChild(card);
     return card;


### PR DESCRIPTION
Ran into this issue when trying to apply utility CSS classes in favor of a custom CSS class wrote just for Notyf. Figured this flexibility would be appreciated!