### PR TITLE
make _pushNotification() smarter

### DIFF
--- a/src/notyf.ts
+++ b/src/notyf.ts
@@ -48,7 +48,9 @@ export default class Notyf {
     const duration = notification.options.duration || this.options.duration;
     setTimeout(() => {
       const index = this.notifications.indexOf(notification);
-      this.notifications.splice(index, 1);
+      if(index!=1){
+        this.notifications.splice(index, 1);         
+      }
     }, duration);
   }
 

--- a/src/notyf.ts
+++ b/src/notyf.ts
@@ -48,7 +48,7 @@ export default class Notyf {
     const duration = notification.options.duration || this.options.duration;
     setTimeout(() => {
       const index = this.notifications.indexOf(notification);
-      if(index!=1){
+      if(index !== -1){
         this.notifications.splice(index, 1);         
       }
     }, duration);


### PR DESCRIPTION
_pushNotification() will push a notification onto the stack, and set a timeout to remove the notification from the stack.  When it's time to remove the notification, if it doesn't find the notification in the stack it will still remove the first item in the stack.  This fixes that.