### PR TITLE
feat: allow custom positioning in viewport

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The codebase is written in TypeScript so you will need at least a bit of familir
 
 ## Tests
 
-Ensure that all tests are passing before opening the pull request. You can do this by running `npm run cy:open` and then click on `notyf_spec.js` to run the suite.
+Ensure that all tests are passing before opening the pull request. To do this, run `npm run test:dev` and then click on `notyf_spec.js` to run the suite.
 
 You'll also need to add unit tests for the features or fixes implemented in your PR. Don't be discouraged by this if you don't feel confident about it. Just open the PR and I will guide you through the process of creating tests for it.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,17 @@ Param | Type | Default | Details
 ------------ | ------------- | ------------- | -------------
 duration | `number` | 2000 | Number of miliseconds before hiding the notification
 ripple | `boolean` | True | Whether to show the notification with a ripple effect
+position | `INotyfPosition` | `{x:'right',y:'bottom'}` | Viewport location in which to render the notifications
 types | `INotyfNotificationOptions[]` | Success and error toasts | Array with individual configurations for each type of toast
+
+### INotyfPosition
+
+Configuration interface to define the viewport location where notifications are rendered.
+
+Param | Type | Details
+------------ | ------------- | -------------
+x | `left \| center \| right` | x-position
+y | `top \| center \| bottom` | y-position
 
 ### INotyfNotificationOptions
 
@@ -97,7 +107,7 @@ Param | Type  | Details
 type | `string` | Notification type for which this configuration will be applied
 className | `string` | Custom class name to be set in the toast wrapper element
 duration | `number` | 2000 | Number of miliseconds before hiding the notification
-icon | `INotyfIcon | false` | An object which the properties of the icon to be rendered. 'false' hides the icon.
+icon | `INotyfIcon \| false` | An object which the properties of the icon to be rendered. 'false' hides the icon.
 backgroundColor | `string` | Background color of the toast
 message | `string` | Message to be rendered inside of the toast. Becomes the default message when used in the global config.
 ripple | `boolean` | Whether or not to render the ripple at revealing
@@ -116,11 +126,19 @@ text | `string` | Inner text rendered within the icon (useful when using [ligatu
 
 ### Global configuration
 
-This is an example of setting Notyf with a 1s duration, custom duration and color for the error toast, and a new custom toast called 'warning' with a [ligature material icon](https://google.github.io/material-design-icons/):
+The following example configures Notyf with the following settings:
+- 1s duration
+- Render notifications in the top-right corner
+- New custom notification called 'warning' with a [ligature material icon](https://google.github.io/material-design-icons/)
+- Error notification with custom duration and color
 
 ```javascript
 const notyf = new Notyf({
   duration: 1000,
+  position: {
+    x: 'right',
+    y: 'top',
+  },
   types: [
     {
       type: 'warning',

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Param | Type | Default | Details
 ------------ | ------------- | ------------- | -------------
 duration | `number` | 2000 | Number of miliseconds before hiding the notification
 ripple | `boolean` | True | Whether to show the notification with a ripple effect
-position | `INotyfPosition` | `{x:'right',y:'bottom'}` | Viewport location in which to render the notifications
+position | `INotyfPosition` | `{x:'right',y:'bottom'}` | Viewport location where notifications are rendered
 types | `INotyfNotificationOptions[]` | Success and error toasts | Array with individual configurations for each type of toast
 
 ### INotyfPosition
@@ -107,7 +107,7 @@ Param | Type  | Details
 type | `string` | Notification type for which this configuration will be applied
 className | `string` | Custom class name to be set in the toast wrapper element
 duration | `number` | 2000 | Number of miliseconds before hiding the notification
-icon | `INotyfIcon \| false` | An object which the properties of the icon to be rendered. 'false' hides the icon.
+icon | `INotyfIcon \| false` | An object with the properties of the icon to be rendered. 'false' hides the icon.
 backgroundColor | `string` | Background color of the toast
 message | `string` | Message to be rendered inside of the toast. Becomes the default message when used in the global config.
 ripple | `boolean` | Whether or not to render the ripple at revealing

--- a/cypress/integration/notyf_spec.js
+++ b/cypress/integration/notyf_spec.js
@@ -13,8 +13,12 @@ context('Notyf', () => {
     cy.get('#code').type(JSON.stringify(obj).replace(new RegExp('{', 'g'), '{{}'), {delay: 0});
   }
 
+  const VIEWPORT_WIDTH = 800;
+  const VIEWPORT_HEIGHT = 800;
+
   beforeEach(() => {
     cy.visit('/');
+    cy.viewport(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
   });
 
   describe('Default behaviour', () => {
@@ -37,7 +41,17 @@ context('Notyf', () => {
     it('should render the notification with ripple', () => {
       cy.get('#error-btn').click();
       cy.get('.notyf__ripple');
-    })
+    });
+
+    it('should position the notification at the bottom right by default.', () => {
+      cy.get('#success-btn').click();
+      cy.get('.notyf__toast').then(button => {
+        const pos = button.position();
+        expect(pos.left).to.be.greaterThan(VIEWPORT_WIDTH/2)
+        expect(pos.top).to.be.greaterThan(VIEWPORT_HEIGHT/2)
+      });
+    });
+
   });
 
   describe('Global custom configuration', () => {
@@ -56,6 +70,71 @@ context('Notyf', () => {
       cy.get('.notyf__toast', { timeout: 10 });
       cy.wait(duration + 1500); // we need to account roughly 1500ms for the css animations to finish
       cy.get('.notyf__toast', { timeout: 10 }).should('not.exist');
+    });
+
+    describe('Positioning', () => {
+
+      function openAt({x, y}) {
+        const config = { position: { x, y } };
+        init(config);
+        cy.get('#success-btn').click();
+      }
+      
+      it('should position the notification at the top left', () => {
+        openAt({ x: 'left', y: 'top' });
+        cy.get('.notyf__toast').then(button => {
+          const { left, top } = button.position();
+          expect(left).to.be.lessThan(VIEWPORT_WIDTH / 2)
+          expect(top).to.be.lessThan(VIEWPORT_HEIGHT / 2)
+        });
+      });
+      
+      it('should position the notification at the top center', () => {
+        openAt({ x: 'center', y: 'top' });
+        cy.get('.notyf__toast').then(button => {
+          const { left, top } = button.position();
+          expect(top).to.be.lessThan(VIEWPORT_HEIGHT / 2);
+          expect(left).to.be.lessThan(VIEWPORT_WIDTH / 2);
+          expect(left + button.width()).to.be.greaterThan(VIEWPORT_WIDTH / 2);
+        });
+      });
+      
+      it('should position the notification at the top right', () => {
+        openAt({ x: 'right', y: 'top' });
+        cy.get('.notyf__toast').then(button => {
+          const { left, top } = button.position();
+          expect(top).to.be.lessThan(VIEWPORT_HEIGHT / 2);
+          expect(left).to.be.greaterThan(VIEWPORT_WIDTH / 2);
+        });
+      });
+      
+      it('should position the notification at the bottom left', () => {
+        openAt({ x: 'left', y: 'bottom' });
+        cy.get('.notyf__toast').then(button => {
+          const { left, top } = button.position();
+          expect(top).to.be.greaterThan(VIEWPORT_HEIGHT / 2);
+          expect(left).to.be.lessThan(VIEWPORT_WIDTH / 2);
+        });
+      });
+      
+      it('should position the notification at the bottom center', () => {
+        openAt({ x: 'center', y: 'bottom' });
+        cy.get('.notyf__toast').then(button => {
+          const { left, top } = button.position();
+          expect(top).to.be.greaterThan(VIEWPORT_HEIGHT / 2);
+          expect(left).to.be.lessThan(VIEWPORT_WIDTH / 2);
+          expect(left + button.width()).to.be.greaterThan(VIEWPORT_WIDTH / 2);
+        });
+      });
+      
+      it('should position the notification at the bottom right', () => {
+        openAt({ x: 'right', y: 'bottom' });
+        cy.get('.notyf__toast').then(button => {
+          const { left, top } = button.position();
+          expect(top).to.be.greaterThan(VIEWPORT_HEIGHT / 2);
+          expect(left).to.be.greaterThan(VIEWPORT_WIDTH / 2);
+        });
+      });
     });
   });
 

--- a/demo/scripts/script-test.js
+++ b/demo/scripts/script-test.js
@@ -41,7 +41,7 @@ function show(type) {
   } else if (type === 'error') {
     notyf.error(input);
   } else {
-    const opts = Object.assign({}, {type}, input);
+    const opts = Object.assign({}, {type}, {message: input});
     notyf.open(opts);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9236,9 +9236,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "test": "npm run build && start-server-and-test dev http://localhost:8080 cy:run",
+    "test:dev": "npm run build && start-server-and-test dev http://localhost:8080 cy:open",
     "lint": "tslint --project tsconfig.json"
   },
   "author": "Carlos Roso",
@@ -45,12 +46,12 @@
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-typescript2": "^0.20.1",
     "rollup-plugin-uglify": "^6.0.2",
-    "tslib": "^1.10.0",
     "sass-loader": "^7.1.0",
     "start-server-and-test": "^1.7.11",
     "ts-loader": "^4.2.0",
+    "tslib": "^1.10.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.8.3",
     "webpack": "4.5.0"
   },
   "repository": {

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,6 +1,6 @@
 # Framework specific recipes
 
-It's no secret that most of the frontend work nowadays is being done using some of the popular frameworks: React, Angular or Vue. Follow these recipes to easily plug in Notyf in your favorite framework.
+Follow these recipes to easily use Notyf in React, Angular or Vue.
 
 ## Recipes
 

--- a/src/notyf.options.ts
+++ b/src/notyf.options.ts
@@ -1,5 +1,13 @@
 export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 
+export type NotyfHorizontalPosition = 'left' | 'center' | 'right';
+export type NotyfVerticalPosition = 'top' | 'center' | 'bottom';
+
+export interface INotyfPosition {
+  x: NotyfHorizontalPosition;
+  y: NotyfVerticalPosition;
+}
+
 export interface INotyfIcon {
   className: string;
   tagName: keyof ElementTagNameMap;
@@ -14,12 +22,14 @@ export interface INotyfNotificationOptions {
   backgroundColor: string;
   message: string;
   ripple: boolean;
+  position: INotyfPosition;
 }
 
 export interface INotyfOptions {
   types: Array<DeepPartial<INotyfNotificationOptions>>;
   duration: number;
   ripple: boolean;
+  position: INotyfPosition;
 }
 
 export const DEFAULT_OPTIONS: INotyfOptions = {
@@ -45,4 +55,8 @@ export const DEFAULT_OPTIONS: INotyfOptions = {
   ],
   duration: 2000,
   ripple: true,
+  position: {
+    x: 'right',
+    y: 'bottom',
+  },
 };

--- a/src/notyf.scss
+++ b/src/notyf.scss
@@ -30,72 +30,91 @@
   }
 }
 
-.notyf__icon--error, .notyf__icon--success{
-    height: 21px;
-    width: 21px;
-    background: white;
-    border-radius: 50%;
-    display: block;
-    margin: 0 auto;
-    position: relative;
-}
+.notyf {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  color: #ffffff;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-end;
+  pointer-events: none;
+  box-sizing: border-box;
+  padding: 20px;
 
-.notyf__icon--error{
-    &:after, &:before{
-      content: "";
-      background: currentColor;
+  &__icon {
+    &--error, &--success {
+      height: 21px;
+      width: 21px;
+      background: white;
+      border-radius: 50%;
       display: block;
-      position: absolute;
-      width: 3px;
-      border-radius: 3px;
-      left: 9px;
-      height: 12px;
-      top: 5px;
+      margin: 0 auto;
+      position: relative;
     }
 
-    &:after{
-      transform: rotate(-45deg);
-    }
-    &:before{
-      transform: rotate(45deg);
-    }
-}
+    &--error {
+      &:after, &:before{
+        content: "";
+        background: currentColor;
+        display: block;
+        position: absolute;
+        width: 3px;
+        border-radius: 3px;
+        left: 9px;
+        height: 12px;
+        top: 5px;
+      }
+  
+      &:after{
+        transform: rotate(-45deg);
+      }
 
-.notyf__icon--success{
-    &:after, &:before{
-      content: "";
-      background: currentColor;
-      display: block;
-      position: absolute;
-      width: 3px;
-      border-radius: 3px;
+      &:before{
+        transform: rotate(45deg);
+      }
     }
-    &:after{
-      height: 6px;
-      transform: rotate(-45deg);
-      top: 9px;
-      left: 6px;
-    }
-    &:before{
-      height: 11px;
-      transform: rotate(45deg);
-      top: 5px;
-      left: 10px;
-    }
-}
 
-.notyf__toast{
+    &--success {
+      &:after, &:before{
+        content: "";
+        background: currentColor;
+        display: block;
+        position: absolute;
+        width: 3px;
+        border-radius: 3px;
+      }
+      &:after{
+        height: 6px;
+        transform: rotate(-45deg);
+        top: 9px;
+        left: 6px;
+      }
+      &:before{
+        height: 11px;
+        transform: rotate(45deg);
+        top: 5px;
+        left: 10px;
+      }
+    }
+  }
+
+  &__toast {
     display: block;
     overflow: hidden;
-    bottom: -100%;
+    pointer-events: auto;
     animation: fadeinup 0.3s ease-in forwards;
     box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.25);
     position: relative;
-    padding: 0 13px;
+    padding: 0 15px;
     border-radius: 2px;
-    margin-top: 12px;
     max-width: 300px;
     transform: translateY(25%);
+    box-sizing: border-box;
 
     &--disappear{
       transform: translateY(0);
@@ -112,68 +131,64 @@
         animation-delay: 0.05s;
       }
     }
-}
 
-.notyf__ripple {
-  height: 400px;
-  width: 400px;
-  position: absolute;
-  transform-origin: bottom right;
-  right: 0;
-  top: 0;
-  border-radius: 50%;
-  transform: scale(0) translateY(-51%) translateX(13%);
-  z-index: 5;
-  animation: ripple 0.4s ease-out forwards;
-}
+    &--upper {
+      margin-bottom: 20px;
+    }
 
-.notyf__wrapper{
-  display: flex;
-  align-items: center;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  padding-right: 15px;
-  border-radius: 3px;
-  position: relative;
-  z-index: 10;
-}
+    &--lower {
+      margin-top: 20px;
+    }
+  }
 
-.notyf__icon{
-  width: 22px;
-  text-align: center;
-  font-size: 1.3em;
-  opacity: 0;
-  animation: fadeinup 0.3s forwards;
-  animation-delay: 0.3s;
-  margin-right: 13px;
-}
+  &__ripple {
+    height: 400px;
+    width: 400px;
+    position: absolute;
+    transform-origin: bottom right;
+    right: 0;
+    top: 0;
+    border-radius: 50%;
+    transform: scale(0) translateY(-51%) translateX(13%);
+    z-index: 5;
+    animation: ripple 0.4s ease-out forwards;
+  }
 
-.notyf__message{
-  vertical-align: middle;
-  position: relative;
-  opacity: 0;
-  animation: fadeinup 0.3s forwards;
-  animation-delay: 0.25s;
-}
+  &__wrapper {
+    display: flex;
+    align-items: center;
+    padding-top: 17px;
+    padding-bottom: 17px;
+    padding-right: 15px;
+    border-radius: 3px;
+    position: relative;
+    z-index: 10;
+  }
 
-.notyf {
-  position: fixed;
-  bottom: 20px;
-  right: 30px;
-  color: white;
-  z-index: 9999;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  &__icon {
+    width: 22px;
+    text-align: center;
+    font-size: 1.3em;
+    opacity: 0;
+    animation: fadeinup 0.3s forwards;
+    animation-delay: 0.3s;
+    margin-right: 13px;
+  }
+
+  &__message {
+    vertical-align: middle;
+    position: relative;
+    opacity: 0;
+    animation: fadeinup 0.3s forwards;
+    animation-delay: 0.25s;
+    line-height: 1.5em;
+  }
 }
 
 /* Small screens */
 @media only screen and (max-width: 480px){
   .notyf {
-    bottom: 0;
-    left: 0;
-    right: 0;
-    align-items: initial;
+    padding: 0;
 
     &__ripple {
       height: 600px;
@@ -185,6 +200,7 @@
       max-width: initial;
       border-radius: 0;
       box-shadow: 0px -2px 7px 0px rgba(0, 0, 0, 0.13);
+      width: 100%;
     }
   }
 }

--- a/src/notyf.ts
+++ b/src/notyf.ts
@@ -39,6 +39,7 @@ export default class Notyf {
     const defaultOpts = this.options.types.find(({type}) => type === options.type) || {};
     const config = {...defaultOpts, ...options};
     config.ripple = config.ripple === undefined ? this.options.ripple : config.ripple;
+    config.position = config.position || this.options.position;
     const notification = new NotyfNotification(config);
     this._pushNotification(notification);
   }


### PR DESCRIPTION
This PR allows users to define a custom position in the viewport to render the notifications: 

```javascript
const notyf = new Notyf({
  position: {
    x: 'center',
    y: 'top'
  }
})
```

The `position` config object follows the following contract:
```typescript
position: {
  x: 'left' | 'center' | 'right',
  y: 'top' | 'center' | 'bottom'
}
```