### PR TITLE
Implement dismiss functionality for single notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ testem.log
 Thumbs.db
 
 # Cypress files
-cypress/screenshots
+cypress/screenshots.vscode

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ position | [`INotyfPosition`](#inotyfposition) | `{x:'right',y:'bottom'}` | View
 dismissible | `boolean` | false | Whether to allow users to dismiss the notification with a button
 types | [`INotyfNotificationOptions[]`](#inotyfnotificationoptions) | Success and error toasts | Array with individual configurations for each type of toast
 
+### `dismiss(notification: NotyfNotification)`
+
+Dismiss a specific notification.
+
+```javascript
+const notyf = new Notyf();
+const notification = notyf.success('Address updated');
+notyf.dismiss(notification);
+```
+
 ### `dismissAll()`
 
 Dismiss all the active notifications.

--- a/cypress/integration/notyf_spec.js
+++ b/cypress/integration/notyf_spec.js
@@ -370,6 +370,20 @@ context('Notyf', () => {
   });
 
   describe('Public API', () => {
+
+    it('should dismiss one notification', () => {
+      const duration = 0; // Infinite duration so that dismissing manually can be verified
+      const config = { duration };
+      init(config);
+      cy.get('#success-btn').click();
+      cy.get('.notyf__toast').should('have.length', 1);
+      cy.window().then(win => {
+        const notification = win.notyfNotifications[win.notyfNotifications - 1]; // Get the latest notification
+        win.notyf.dismiss(notification);
+        cy.wait(1500); // we need to account roughly 1500ms for the css animations to finish
+        cy.get('.notyf__toast', { timeout: 10 }).should('not.exist');
+      });
+    });
     
     it('should dismiss all notifications', () => {
       init();
@@ -381,5 +395,6 @@ context('Notyf', () => {
       cy.get('#dismiss-all-btn').click();
       cy.get('.notyf__toast').should('have.length', 0);
     });
+
   });
 });

--- a/demo/scripts/script-test.js
+++ b/demo/scripts/script-test.js
@@ -1,4 +1,5 @@
 var notyf;
+var notyfNotifications = [];
 
 document.getElementById('success-btn')
         .addEventListener('click', function(){
@@ -39,20 +40,23 @@ function init() {
 
 function dismissAll() {
   notyf.dismissAll();
+  notyfNotifications.length = 0;
 }
 
 function show(type) {
   const message = document.getElementById('message').value;
   const options = JSON.parse(document.getElementById('code').value || '{}');
   let input = message || options;
+  let notification;
   // if message is non null then call notyf with the message
   // otherwise open the notyf with the config object
   if (type === 'success') {
-    notyf.success(input);
+    notification = notyf.success(input);
   } else if (type === 'error') {
-    notyf.error(input);
+    notification = notyf.error(input);
   } else {
     const opts = Object.assign({}, {type}, {message: input});
-    notyf.open(opts);
+    notification = notyf.open(opts);
   }
+  notyfNotifications.push(notification);
 }

--- a/src/notyf.ts
+++ b/src/notyf.ts
@@ -24,25 +24,26 @@ export default class Notyf {
     this.view.on(NotyfEvent.Dismiss, elem => this._removeNotification(elem));
   }
 
-  public error(payload: string | Partial<INotyfNotificationOptions>)  {
+  public error(payload: string | Partial<INotyfNotificationOptions>): NotyfNotification  {
     const options = this.normalizeOptions('error', payload);
-    this.open(options);
+    return this.open(options);
   }
 
-  public success(payload: string | Partial<INotyfNotificationOptions>) {
+  public success(payload: string | Partial<INotyfNotificationOptions>): NotyfNotification {
     const options = this.normalizeOptions('success', payload);
-    this.open(options);
+    return this.open(options);
   }
 
-  public open(options: DeepPartial<INotyfNotificationOptions>) {
+  public open(options: DeepPartial<INotyfNotificationOptions>): NotyfNotification {
     const defaultOpts = this.options.types.find(({type}) => type === options.type) || {};
     const config = {...defaultOpts, ...options};
     this.assignProps(['ripple', 'position', 'dismissible'], config);
     const notification = new NotyfNotification(config);
     this._pushNotification(notification);
+    return notification;
   }
 
-  public dismissAll() {
+  public dismissAll(): void {
     while (this.notifications.splice(0, 1));
   }
 
@@ -81,6 +82,8 @@ export default class Notyf {
       this.notifications.splice(index, 1);
     }
   }
+
+  public dismiss = this._removeNotification;
 
   private normalizeOptions(
     type: 'success' | 'error',


### PR DESCRIPTION
- [X]  Implement feature
- [X]  Update doc
- [X]  Add spec

Closes Issue #20

Create a `dismiss` method while keeping the `_removeNotification` method for backward compatibility purposes (for people who might be relying on this method)