### PR TITLE
don't allow toasts to shrink

### DIFF
--- a/src/notyf.scss
+++ b/src/notyf.scss
@@ -139,6 +139,7 @@ $toast-padding: 15px;
     max-width: 300px;
     transform: translateY(25%);
     box-sizing: border-box;
+    flex: none;
 
     &--disappear{
       transform: translateY(0);


### PR DESCRIPTION
If you happen to have a really long list of toasts active, they would start to shrink because of the flex container.

![Screen Shot 2020-06-07 at 20 51 39](https://user-images.githubusercontent.com/631691/83978615-ba5d6b00-a900-11ea-8ece-13961fbbd9a6.png)

With the `flex: none` style on the toast the oldest ones disappear from the viewport and no toast is shrunk:

![Screen Shot 2020-06-07 at 20 52 31](https://user-images.githubusercontent.com/631691/83978639-d3feb280-a900-11ea-8626-91db5e619222.png)
