### PR TITLE
Add UMD build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Notyf is a minimalistic JavaScript library for toast notifications. It's respons
 - 📱 Responsive
 - 👓 A11Y compatible
 - 🔥 Strongly typed codebase (TypeScript Typings readily available)
-- ⚡️ 3 types of bundles exposed: ES6, CommonJS and IIFE (for vanilla, framework-free usage).
+- ⚡️ 4 types of bundles exposed: ES6, CommonJS, UMD, and IIFE (for vanilla, framework-free usage).
 - 🎯 End-to-end testing with Cypress
 - 🎸 Easily plugable to modern frameworks. Recipes available to integrate with React, Angular, Vue, and Svelte.
 - ✨ Optional ripple-like fancy revealing effect
@@ -136,7 +136,7 @@ notification.on('click', ({target, event}) => {
 
 ### `'dismiss'`
 
-Triggers when the notification is **manually** (not programatically) dismissed. 
+Triggers when the notification is **manually** (not programatically) dismissed.
 
 ```javascript
 const notyf = new Notyf();

--- a/build.js
+++ b/build.js
@@ -35,6 +35,14 @@ const bundles = [
     file: 'notyf.min.js',
     input: 'src/notyf.ts',
   },
+  {
+    format: 'umd',
+    babelPresets: ['es2015-rollup', 'stage-1'],
+    babelPlugins: [],
+    name: 'Notyf',
+    file: 'notyf.umd.js',
+    input: 'src/notyf.ts',
+  },
 ];
 
 let promise = Promise.resolve();


### PR DESCRIPTION
Hi :wave: first of all, thx for amazing for on this lib 🤟

I would like to use it in Chrome extension I'm working on, but:

* I don't have a compile step -> cannot use the module version
* Chrome Web Store disallow minified code in extensions -> cannot use minified IIFE version

This PR adds `.umd.js` bundle which have UMD preamble

```
(function (global, factory) {
    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
    typeof define === 'function' && define.amd ? define(factory) :
    (global = global || self, global.Notyf = factory());
}(this, (function () { 'use strict';

// ...
```

Closes #78 