### PR TITLE
added info and warning types

### DIFF
--- a/src/notyf.options.ts
+++ b/src/notyf.options.ts
@@ -47,6 +47,24 @@ export interface INotyfOptions {
 export const DEFAULT_OPTIONS: INotyfOptions = {
   types: [
     {
+      type: 'info',
+      className: 'notyf__toast--info',
+      backgroundColor: '#4287f5',
+      icon: {
+        className: 'notyf__icon--info',
+        tagName: 'i',
+      },
+    },
+    {
+      type: 'warning',
+      className: 'notyf__toast--warning',
+      backgroundColor: '#fcba03',
+      icon: {
+        className: 'notyf__icon--warning',
+        tagName: 'i',
+      },
+    },
+    {
       type: 'success',
       className: 'notyf__toast--success',
       backgroundColor: '#3dc763',

--- a/src/notyf.scss
+++ b/src/notyf.scss
@@ -71,7 +71,7 @@ $toast-padding: 15px;
   padding: 20px;
 
   &__icon {
-    &--error, &--success {
+    &--error, &--success, &--info, &--warning {
       height: 21px;
       width: 21px;
       background: white;
@@ -104,6 +104,52 @@ $toast-padding: 15px;
     }
 
     &--success {
+      &:after, &:before{
+        content: "";
+        background: currentColor;
+        display: block;
+        position: absolute;
+        width: 3px;
+        border-radius: 3px;
+      }
+      &:after{
+        height: 6px;
+        transform: rotate(-45deg);
+        top: 9px;
+        left: 6px;
+      }
+      &:before{
+        height: 11px;
+        transform: rotate(45deg);
+        top: 5px;
+        left: 10px;
+      }
+    }
+
+    &--info {
+      &:after, &:before{
+        content: "";
+        background: currentColor;
+        display: block;
+        position: absolute;
+        width: 3px;
+        border-radius: 3px;
+      }
+      &:after{
+        height: 6px;
+        transform: rotate(-45deg);
+        top: 9px;
+        left: 6px;
+      }
+      &:before{
+        height: 11px;
+        transform: rotate(45deg);
+        top: 5px;
+        left: 10px;
+      }
+    }
+
+    &--warning {
       &:after, &:before{
         content: "";
         background: currentColor;

--- a/src/notyf.scss
+++ b/src/notyf.scss
@@ -93,63 +93,15 @@ $toast-padding: 15px;
         height: 12px;
         top: 5px;
       }
-  
       &:after{
         transform: rotate(-45deg);
       }
-
       &:before{
         transform: rotate(45deg);
       }
     }
-
-    &--success {
-      &:after, &:before{
-        content: "";
-        background: currentColor;
-        display: block;
-        position: absolute;
-        width: 3px;
-        border-radius: 3px;
-      }
-      &:after{
-        height: 6px;
-        transform: rotate(-45deg);
-        top: 9px;
-        left: 6px;
-      }
-      &:before{
-        height: 11px;
-        transform: rotate(45deg);
-        top: 5px;
-        left: 10px;
-      }
-    }
-
-    &--info {
-      &:after, &:before{
-        content: "";
-        background: currentColor;
-        display: block;
-        position: absolute;
-        width: 3px;
-        border-radius: 3px;
-      }
-      &:after{
-        height: 6px;
-        transform: rotate(-45deg);
-        top: 9px;
-        left: 6px;
-      }
-      &:before{
-        height: 11px;
-        transform: rotate(45deg);
-        top: 5px;
-        left: 10px;
-      }
-    }
-
-    &--warning {
+ 
+    &--success, &--info, &--warning {
       &:after, &:before{
         content: "";
         background: currentColor;

--- a/src/notyf.ts
+++ b/src/notyf.ts
@@ -47,6 +47,16 @@ export default class Notyf {
     return this.open(options);
   }
 
+  public info(payload: string | Partial<INotyfNotificationOptions>) {
+    const options = this.normalizeOptions('info', payload);
+    return this.open(options);
+  }
+
+  public warning(payload: string | Partial<INotyfNotificationOptions>) {
+    const options = this.normalizeOptions('warning', payload);
+    return this.open(options);
+  }
+
   public open(options: DeepPartial<INotyfNotificationOptions>) {
     const defaultOpts = this.options.types.find(({ type }) => type === options.type) || {};
     const config = { ...defaultOpts, ...options };
@@ -98,7 +108,7 @@ export default class Notyf {
   }
 
   private normalizeOptions(
-    type: 'success' | 'error',
+    type: 'success' | 'error' | 'info' | 'warning',
     payload: string | DeepPartial<INotyfNotificationOptions>,
   ): DeepPartial<INotyfNotificationOptions> {
     let options: DeepPartial<INotyfNotificationOptions> = { type };


### PR DESCRIPTION
Please add just the 4 basic types of toaster? This is the default clasess:

- warning
- info
- success
- error

Then I can use this code and do clean replacement of the toastr.js plugin I was using 😁