### PR TITLE
feat( options ): add the capability to use an HTML element in the icon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Param | Type  | Details
 type | `string` | Notification type for which this configuration will be applied
 className | `string` | Custom class name to be set in the toast wrapper element
 duration | `number` | 2000 | Number of miliseconds before hiding the notification
-icon | [`INotyfIcon \| false`](#inotyficon) | An object with the properties of the icon to be rendered. 'false' hides the icon.
+icon | `HTMLElement` [`INotyfIcon`](#inotyficon) `false` | An object with the properties of the icon to be rendered. 'false' hides the icon.
 background | `string` | Background color of the toast
 message | `string` | Message to be rendered inside of the toast. Becomes the default message when used in the global config.
 ripple | `boolean` | Whether or not to render the ripple at revealing

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Param | Type  | Details
 type | `string` | Notification type for which this configuration will be applied
 className | `string` | Custom class name to be set in the toast wrapper element
 duration | `number` | 2000 | Number of miliseconds before hiding the notification
-icon | `HTMLElement` [`INotyfIcon`](#inotyficon) `false` | An object with the properties of the icon to be rendered. 'false' hides the icon.
+icon | `string` [`INotyfIcon`](#inotyficon) `false` | An object with the properties of the icon to be rendered. 'false' hides the icon.
 background | `string` | Background color of the toast
 message | `string` | Message to be rendered inside of the toast. Becomes the default message when used in the global config.
 ripple | `boolean` | Whether or not to render the ripple at revealing

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/notyf_spec.js
+++ b/cypress/integration/notyf_spec.js
@@ -3,13 +3,13 @@
 context('Notyf', () => {
   function init(config) {
     if (config) {
-      typeCode(config);
+      setConfiguration(config);
     }
     cy.get('#init-btn').click();
   }
 
-  function typeCode(obj) {
-    return cy.get('#code').type(JSON.stringify(obj).replace(new RegExp('{', 'g'), '{{}'), { delay: 0 });
+  function setConfiguration(obj) {
+    return cy.window().invoke('setConfiguration', obj)
   }
 
   function checkPrintOutput(message) {
@@ -274,7 +274,7 @@ context('Notyf', () => {
     it('should render with a custom message passed as a config object', () => {
       const message = 'I love Notyf';
       const config = { message };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#error-btn').click();
       cy.get('.notyf__message').should('have.text', message);
     });
@@ -282,7 +282,7 @@ context('Notyf', () => {
     it('should render html messages', () => {
       const message = '<p>My <b>html</b> <span class="foo">message</span></p>';
       const config = { message };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#error-btn').click();
       cy.get('.notyf__message').find('p').find('span').should('have.class', 'foo');
     });
@@ -290,7 +290,7 @@ context('Notyf', () => {
     it('should remove the notification after the given duration', () => {
       const duration = 3000;
       const config = { duration };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__toast', { timeout: 10 });
       cy.wait(duration + 1500); // we need to account roughly 1500ms for the css animations to finish
@@ -300,7 +300,7 @@ context('Notyf', () => {
     it('should render with custom class name', () => {
       const className = 'foo-bar-class';
       const config = { className };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__toast').should('have.class', className);
     });
@@ -308,7 +308,7 @@ context('Notyf', () => {
     it('should render with multiple custom class names', () => {
       const className = 'foo-bar-class another-class';
       const config = { className };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__toast').should('have.class', className);
     });
@@ -317,7 +317,7 @@ context('Notyf', () => {
       const ripple = false;
       const backgroundColor = 'cyan';
       const config = { ripple, backgroundColor };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__ripple', { timeout: 10 }).should('not.exist');
       cy.get('.notyf__toast').then(([elem]) => {
@@ -328,7 +328,7 @@ context('Notyf', () => {
     it('should render the toast with custom background color', () => {
       const backgroundColor = 'cyan';
       const config = { backgroundColor };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__ripple').then(([elem]) => {
         expect(elem.style.backgroundColor).to.equal(backgroundColor);
@@ -341,21 +341,44 @@ context('Notyf', () => {
     it('should render the toast with custom background', () => {
       const background = 'linear-gradient(45deg, red, green)';
       const config = { background };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__ripple').then(([elem]) => {
         expect(elem.style.background).to.equal(background);
       });
     });
 
-    it('should render with a custom icon', () => {
+    it('should render with a custom configuration-based icon', () => {
       const className = 'foo-bar-icon';
       const tagName = 'span';
       const text = 'baz';
       const color = 'white';
       const icon = { className, tagName, text, color };
       const config = { icon };
-      typeCode(config);
+      setConfiguration(config);
+      cy.get('#success-btn').click();
+      cy.get('.notyf__icon')
+        .find(tagName)
+        .should('have.class', className)
+        .should('have.text', text)
+        .then(([elem]) => {
+          expect(elem.style.color).to.equal(color);
+        });
+    });
+
+    it('should render with a custom HTMLElement-based icon', () => {
+      const tagName = 'span';
+      const className = 'foo-bar-icon';
+      const text = 'baz';
+      const color = 'white';
+      
+      const icon = document.createElement(tagName)
+      icon.classList.add(className)
+      icon.innerText = text
+      icon.style.color = color
+
+      const config = { icon };
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__icon')
         .find(tagName)
@@ -369,7 +392,7 @@ context('Notyf', () => {
     it('should allow the notification to be dismissed manually', () => {
       const duration = 3000;
       const config = { dismissible: true, duration };
-      typeCode(config);
+      setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__dismiss-btn').should('exist').click();
       cy.wait(duration / 2); // if the notification was dismissed, then it should disappear before duration elapsed

--- a/cypress/integration/notyf_spec.js
+++ b/cypress/integration/notyf_spec.js
@@ -377,7 +377,7 @@ context('Notyf', () => {
       icon.innerText = text
       icon.style.color = color
 
-      const config = { icon };
+      const config = { icon: icon.outerHTML };
       setConfiguration(config);
       cy.get('#success-btn').click();
       cy.get('.notyf__icon')

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,9 +35,6 @@
       <label>Custom ID</label>
       <input type="text" id="custom-id">
       <br>
-      <label>Code</label>
-      <textarea id="code" cols="30" rows="10"></textarea>
-      <hr>
       <button id="success-btn-demo" type="button">Success</button>
       <button id="error-btn-demo" type="button">Error</button>
       <script src="../dist/notyf.min.js" type="text/javascript"></script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,6 +35,10 @@
       <label>Custom ID</label>
       <input type="text" id="custom-id">
       <br>
+      <label>Code</label>
+      <textarea name="" id="code" cols="30" rows="10"></textarea>
+      <button id="save">Save</button>
+      <hr>
       <button id="success-btn-demo" type="button">Success</button>
       <button id="error-btn-demo" type="button">Error</button>
       <script src="../dist/notyf.min.js" type="text/javascript"></script>

--- a/demo/scripts/script-test.js
+++ b/demo/scripts/script-test.js
@@ -1,5 +1,6 @@
 var notyf;
 var notyfNotifications = [];
+var configuration = {};
 
 document.getElementById('success-btn').addEventListener('click', function () {
   show('success');
@@ -46,8 +47,7 @@ function init() {
       document.querySelector('.notyf').remove();
     } catch (e) {}
   }
-  const code = JSON.parse(document.getElementById('code').value || '{}');
-  notyf = new Notyf(code);
+  notyf = new Notyf(configuration);
 }
 
 function dismiss(idx) {
@@ -66,8 +66,7 @@ function print(msg) {
 
 function show(type) {
   const message = document.getElementById('message').value;
-  const options = JSON.parse(document.getElementById('code').value || '{}');
-  let input = message || options;
+  let input = message || configuration;
   let notification;
   // if message is non null then call notyf with the message
   // otherwise open the notyf with the config object
@@ -80,4 +79,8 @@ function show(type) {
     notification = notyf.open(opts);
   }
   notyfNotifications.push(notification);
+}
+
+function setConfiguration (newConfiguration) {
+  configuration = typeof newConfiguration === 'function' ? newConfiguration() : newConfiguration
 }

--- a/demo/scripts/script-test.js
+++ b/demo/scripts/script-test.js
@@ -2,6 +2,12 @@ var notyf;
 var notyfNotifications = [];
 var configuration = {};
 
+const textarea = document.getElementById('code')
+
+document.getElementById('save').addEventListener('click', function () {
+  setConfiguration(textarea.value)
+})
+
 document.getElementById('success-btn').addEventListener('click', function () {
   show('success');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2102,9 +2102,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001094",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001094.tgz",
-      "integrity": "sha512-ufHZNtMaDEuRBpTbqD93tIQnngmJ+oBknjvr0IbFympSdtFpAUFmNv4mVKbb53qltxFx0nK3iy32S9AqkLzUNA==",
+      "version": "1.0.30001219",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz",
+      "integrity": "sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==",
       "dev": true
     },
     "caseless": {

--- a/src/notyf.options.ts
+++ b/src/notyf.options.ts
@@ -24,7 +24,7 @@ export interface INotyfNotificationOptions {
   type: string;
   className: string;
   duration: number;
-  icon: INotyfIcon | false;
+  icon: HTMLElement | INotyfIcon | false;
   /**
    * @deprecated Use `background` instead. Removal target: v4.0.0.
    */

--- a/src/notyf.options.ts
+++ b/src/notyf.options.ts
@@ -24,7 +24,7 @@ export interface INotyfNotificationOptions {
   type: string;
   className: string;
   duration: number;
-  icon: HTMLElement | INotyfIcon | false;
+  icon: string | INotyfIcon | false;
   /**
    * @deprecated Use `background` instead. Removal target: v4.0.0.
    */

--- a/src/notyf.view.ts
+++ b/src/notyf.view.ts
@@ -151,10 +151,8 @@ export class NotyfView {
 
         const { tagName = 'i', className, text, color = mainColor } = iconOpts
 
-        const iconElement: HTMLElement = document.createElement(tagName)
+        const iconElement: HTMLElement = this._createHTLMElement({ tagName, className, text });
         
-        if ( className ) iconElement.classList.add( className );
-        if ( text ) iconElement.innerText = text
         if ( color ) iconElement.style.color = color;
 
         iconContainer.appendChild(iconElement);

--- a/src/notyf.view.ts
+++ b/src/notyf.view.ts
@@ -35,7 +35,7 @@ export class NotyfView {
   constructor() {
     // Creates the main notifications container
     const docFrag = document.createDocumentFragment();
-    const notyfContainer = this._createHTLMElement({ tagName: 'div', className: 'notyf' });
+    const notyfContainer = this._createHTMLElement({ tagName: 'div', className: 'notyf' });
     docFrag.appendChild(notyfContainer);
     document.body.appendChild(docFrag);
     this.container = notyfContainer;
@@ -132,10 +132,10 @@ export class NotyfView {
     this.adjustContainerAlignment(options);
 
     // Create elements
-    const notificationElem = this._createHTLMElement({ tagName: 'div', className: 'notyf__toast' });
-    const ripple = this._createHTLMElement({ tagName: 'div', className: 'notyf__ripple' });
-    const wrapper = this._createHTLMElement({ tagName: 'div', className: 'notyf__wrapper' });
-    const message = this._createHTLMElement({ tagName: 'div', className: 'notyf__message' });
+    const notificationElem = this._createHTMLElement({ tagName: 'div', className: 'notyf__toast' });
+    const ripple = this._createHTMLElement({ tagName: 'div', className: 'notyf__ripple' });
+    const wrapper = this._createHTMLElement({ tagName: 'div', className: 'notyf__wrapper' });
+    const message = this._createHTMLElement({ tagName: 'div', className: 'notyf__message' });
 
     message.innerHTML = options.message || '';
     const mainColor = options.background || options.backgroundColor;
@@ -143,7 +143,7 @@ export class NotyfView {
     // Build the icon and append it to the card
     if ( iconOpts ) {
       
-      const iconContainer = this._createHTLMElement({ tagName: 'div', className: 'notyf__icon' });
+      const iconContainer = this._createHTMLElement({ tagName: 'div', className: 'notyf__icon' });
 
       if ( typeof iconOpts === 'string' ) iconContainer.innerHTML = iconOpts
 
@@ -151,7 +151,7 @@ export class NotyfView {
 
         const { tagName = 'i', className, text, color = mainColor } = iconOpts
 
-        const iconElement: HTMLElement = this._createHTLMElement({ tagName, className, text });
+        const iconElement: HTMLElement = this._createHTMLElement({ tagName, className, text });
         
         if ( color ) iconElement.style.color = color;
 
@@ -178,8 +178,8 @@ export class NotyfView {
 
     // Add dismiss button
     if (options.dismissible) {
-      const dismissWrapper = this._createHTLMElement({ tagName: 'div', className: 'notyf__dismiss' });
-      const dismissButton = this._createHTLMElement({
+      const dismissWrapper = this._createHTMLElement({ tagName: 'div', className: 'notyf__dismiss' });
+      const dismissButton = this._createHTMLElement({
         tagName: 'button',
         className: 'notyf__dismiss-btn',
       }) as HTMLButtonElement;
@@ -202,7 +202,7 @@ export class NotyfView {
     return notificationElem;
   }
 
-  private _createHTLMElement({
+  private _createHTMLElement({
     tagName,
     className,
     text,
@@ -224,7 +224,7 @@ export class NotyfView {
    * screen readers
    */
   private _createA11yContainer() {
-    const a11yContainer = this._createHTLMElement({ tagName: 'div', className: 'notyf-announcer' });
+    const a11yContainer = this._createHTMLElement({ tagName: 'div', className: 'notyf-announcer' });
     a11yContainer.setAttribute('aria-atomic', 'true');
     a11yContainer.setAttribute('aria-live', 'polite');
     // Set the a11y container to be visible hidden. Can't use display: none as

--- a/src/notyf.view.ts
+++ b/src/notyf.view.ts
@@ -138,43 +138,43 @@ export class NotyfView {
     const message = this._createHTLMElement({ tagName: 'div', className: 'notyf__message' });
 
     message.innerHTML = options.message || '';
-    const color = options.background || options.backgroundColor;
+    const mainColor = options.background || options.backgroundColor;
 
     // Build the icon and append it to the card
-    if (iconOpts && typeof iconOpts === 'object') {
+    if ( iconOpts ) {
+      
       const iconContainer = this._createHTLMElement({ tagName: 'div', className: 'notyf__icon' });
-      if (this._isHTMLElement(iconOpts)) {
-        const iconElement: HTMLElement = iconOpts as HTMLElement;
-        iconContainer.appendChild(iconElement);
-        wrapper.appendChild(iconContainer);
-      } else {
-        const iconConfiguration: DeepPartial<INotyfIcon> = iconOpts as INotyfIcon;
 
-        const iconElement: HTMLElement = this._createHTLMElement({
-          tagName: iconConfiguration.tagName || 'i',
-          className: iconConfiguration.className,
-          text: iconConfiguration.text,
-        });
+      if ( typeof iconOpts === 'string' ) iconContainer.innerHTML = iconOpts
 
-        const iconColor = iconConfiguration.color ?? color;
+      if ( typeof iconOpts === 'object' ) {
 
-        if (iconColor) iconElement.style.color = iconColor;
+        const { tagName = 'i', className, text, color = mainColor } = iconOpts
+
+        const iconElement: HTMLElement = document.createElement(tagName)
+        
+        if ( className ) iconElement.classList.add( className );
+        if ( text ) iconElement.innerText = text
+        if ( color ) iconElement.style.color = color;
 
         iconContainer.appendChild(iconElement);
-        wrapper.appendChild(iconContainer);
+        
       }
+      
+      wrapper.appendChild(iconContainer);
+
     }
 
     wrapper.appendChild(message);
     notificationElem.appendChild(wrapper);
 
     // Add ripple if applicable, else just paint the full toast
-    if (color) {
+    if (mainColor) {
       if (options.ripple) {
-        ripple.style.background = color;
+        ripple.style.background = mainColor;
         notificationElem.appendChild(ripple);
       } else {
-        notificationElem.style.background = color;
+        notificationElem.style.background = mainColor;
       }
     }
 
@@ -219,16 +219,6 @@ export class NotyfView {
     }
     elem.textContent = text || null;
     return elem;
-  }
-
-  private _isHTMLElement (element: any): element is HTMLElement {
-    try {
-      const container = document.createElement('div');
-      container.appendChild(element as HTMLElement);
-    } catch (err) {
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/src/notyf.view.ts
+++ b/src/notyf.view.ts
@@ -145,7 +145,7 @@ export class NotyfView {
       
       const iconContainer = this._createHTMLElement({ tagName: 'div', className: 'notyf__icon' });
 
-      if ( typeof iconOpts === 'string' ) iconContainer.innerHTML = iconOpts
+      if ( typeof iconOpts === 'string' || iconOpts instanceof String ) iconContainer.innerHTML = new String(iconOpts).valueOf()
 
       if ( typeof iconOpts === 'object' ) {
 

--- a/src/notyf.view.ts
+++ b/src/notyf.view.ts
@@ -10,6 +10,7 @@ import {
   DeepPartial,
   INotyfNotificationOptions,
   NotyfEvent,
+  INotyfIcon,
 } from './notyf.options';
 
 export class NotyfView {
@@ -142,17 +143,31 @@ export class NotyfView {
     // Build the icon and append it to the card
     if (iconOpts && typeof iconOpts === 'object') {
       const iconContainer = this._createHTLMElement({ tagName: 'div', className: 'notyf__icon' });
-      const icon = this._createHTLMElement({
-        tagName: iconOpts.tagName || 'i',
-        className: iconOpts.className,
-        text: iconOpts.text,
-      });
-      const iconColor = iconOpts.color ?? color;
-      if (iconColor) {
-        icon.style.color = iconColor;
+      
+      if ( iconOpts instanceof HTMLElement ) {
+        
+        const iconElement: HTMLElement = iconOpts as HTMLElement
+        iconContainer.appendChild(iconElement);
+        wrapper.appendChild(iconContainer);
+
+      } else {
+
+        const iconConfiguration: DeepPartial<INotyfIcon> = iconOpts as INotyfIcon;
+
+        const iconElement: HTMLElement = this._createHTLMElement({
+          tagName: iconConfiguration.tagName || 'i',
+          className: iconConfiguration.className,
+          text: iconConfiguration.text,
+        });
+  
+        const iconColor = iconConfiguration.color ?? color;
+  
+        if (iconColor) iconElement.style.color = iconColor;
+  
+        iconContainer.appendChild(iconElement);
+        wrapper.appendChild(iconContainer)
       }
-      iconContainer.appendChild(icon);
-      wrapper.appendChild(iconContainer);
+
     }
 
     wrapper.appendChild(message);

--- a/src/notyf.view.ts
+++ b/src/notyf.view.ts
@@ -143,15 +143,11 @@ export class NotyfView {
     // Build the icon and append it to the card
     if (iconOpts && typeof iconOpts === 'object') {
       const iconContainer = this._createHTLMElement({ tagName: 'div', className: 'notyf__icon' });
-      
-      if ( iconOpts instanceof HTMLElement ) {
-        
-        const iconElement: HTMLElement = iconOpts as HTMLElement
+      if (this._isHTMLElement(iconOpts)) {
+        const iconElement: HTMLElement = iconOpts as HTMLElement;
         iconContainer.appendChild(iconElement);
         wrapper.appendChild(iconContainer);
-
       } else {
-
         const iconConfiguration: DeepPartial<INotyfIcon> = iconOpts as INotyfIcon;
 
         const iconElement: HTMLElement = this._createHTLMElement({
@@ -159,15 +155,14 @@ export class NotyfView {
           className: iconConfiguration.className,
           text: iconConfiguration.text,
         });
-  
-        const iconColor = iconConfiguration.color ?? color;
-  
-        if (iconColor) iconElement.style.color = iconColor;
-  
-        iconContainer.appendChild(iconElement);
-        wrapper.appendChild(iconContainer)
-      }
 
+        const iconColor = iconConfiguration.color ?? color;
+
+        if (iconColor) iconElement.style.color = iconColor;
+
+        iconContainer.appendChild(iconElement);
+        wrapper.appendChild(iconContainer);
+      }
     }
 
     wrapper.appendChild(message);
@@ -224,6 +219,16 @@ export class NotyfView {
     }
     elem.textContent = text || null;
     return elem;
+  }
+
+  private _isHTMLElement (element: any): element is HTMLElement {
+    try {
+      const container = document.createElement('div');
+      container.appendChild(element as HTMLElement);
+    } catch (err) {
+      return false;
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
I provided a possibility of passing HTML element to icon option as a shorthand of their config to increase a possibility of customization beside the traditional way

```javascript
const IconOptions = {
 tagName: 'svg',
 className: '.notyf__icon',
 text: ' . . . ',
 color: 'red'
}

const IconElement = document.createElement('svg')
IconElement.classList.add('notyf__icon')
IconElement.innerHTML = ' . . . '
IconElement.style.color = 'red'

const notyf = new Notyf({
 icon: IconElement // or IconOptions
});
```

It will fix issue #87 and more like it