### PR TITLE
Small optimizations + improvements

### DIFF
--- a/src/notyf.ts
+++ b/src/notyf.ts
@@ -38,22 +38,22 @@ export default class Notyf {
   }
 
   public error(payload: string | Partial<INotyfNotificationOptions>) {
-    const options = this.normalizeOptions('error', payload);
-    return this.open(options);
+    return this.open(this.normalizeOptions('error', payload));
   }
 
   public success(payload: string | Partial<INotyfNotificationOptions>) {
-    const options = this.normalizeOptions('success', payload);
-    return this.open(options);
+    return this.open(this.normalizeOptions('success', payload));
   }
 
   public open(options: DeepPartial<INotyfNotificationOptions>) {
-    const defaultOpts = this.options.types.find(({ type }) => type === options.type) || {};
-    const config = { ...defaultOpts, ...options };
-    this.assignProps(['ripple', 'position', 'dismissible'], config);
-    const notification = new NotyfNotification(config);
-    this._pushNotification(notification);
-    return notification;
+    if (Object.prototype.toString.call(options).slice(8, -1) === 'Object' && typeof options.message === 'string') {
+      const defaultOpts = this.options.types.find(({ type }) => type === options.type) || {};
+      const config = { ...defaultOpts, ...options };
+      this.assignProps(['ripple', 'position', 'dismissible'], config);
+      const notification = new NotyfNotification(config);
+      this._pushNotification(notification);
+      return notification;
+    }
   }
 
   public dismissAll() {
@@ -84,7 +84,7 @@ export default class Notyf {
   private _pushNotification(notification: NotyfNotification) {
     this.notifications.push(notification);
     const duration =
-      notification.options.duration !== undefined ? notification.options.duration : this.options.duration;
+      notification.options.duration === undefined ? this.options.duration : notification.options.duration;
     if (duration) {
       setTimeout(() => this._removeNotification(notification), duration);
     }
@@ -104,8 +104,8 @@ export default class Notyf {
     let options: DeepPartial<INotyfNotificationOptions> = { type };
     if (typeof payload === 'string') {
       options.message = payload;
-    } else if (typeof payload === 'object') {
-      options = { ...options, ...payload };
+    } else if (Object.prototype.toString.call(payload).slice(8, -1) === 'Object') {
+      options = { ...payload, ...options };
     }
     return options;
   }


### PR DESCRIPTION
The proposed update

1. Optimizes functions `success` and `error` to get rid of redundant constant declaration
2. Improves function `normalizeOptions`, implementing strict type checking  for `payload` object. The method `typeof payload === 'object'`, used before, fails to detect the type clearly, if passed payload inherits Object prototype being de facto non classic Object. This can lead to possible uncaught runime errors and at least results in displaying empty notification. For example, `notyf.error(Array.of('They see me rolling'))`, `notyf.error(new String('They see me rolling'))` or `notyf.success(null)`, since the check `typeof Array.of('They see me rolling')`, `typeof new String('They see me rolling')` and `typeof null` will identify these Array, String and Null instances as `object`
3. Improves function `normalizeOptions`, correcting the logic of workflow (*although it may be subject for discussion*) by swapping the order of `payload` and `options` during the merge.  (`options = { ...options, ...payload }` => `options = { ...payload, ...options }`). The point is to assure the notification, produced by options normalization subroutine, is exactly of type passed in 1st argument to `normalizeOptions(type, payload)` function regardless of properties of payload object. The logic, used before swapping, could result in curious things like invocation of `notyf.error({ type : 'success', message : 'They see me rolling' })`, which despite the name produces the notification of type `success`
4. Improves function `open`, covering the original code with additional check to assure the argument passed to `notyf.open(options)` function is of expected classic Object type and this `option` object contains property `message` with value of type String. The point is to  avoid arrival of empty notifications if for some reason the options hasn't been combined properly. This improvement has an impact only on accidental failures and one still is able to push an empty notification like `notyf.error('')` or `notyf.open({ type : 'success', message : '' })`, declaring message as empty string